### PR TITLE
Turn Clippy into a GTK module

### DIFF
--- a/src/clippy.c
+++ b/src/clippy.c
@@ -19,6 +19,7 @@
  * Author: Juan Pablo Ugarte <ugarte@endlessm.com>
  */
 
+#include <gmodule.h>
 #include <gtk/gtk.h>
 #include "utils.h"
 
@@ -459,8 +460,8 @@ clippy_idle (gpointer user_data)
   return G_SOURCE_REMOVE;
 }
 
-__attribute__((constructor))
-void clippy_init (void)
+G_MODULE_EXPORT void
+gtk_module_init(gint *argc, gchar ***argv)
 {
   GDBusNodeInfo *info;
   GError *error = NULL;
@@ -483,3 +484,8 @@ void clippy_init (void)
     g_debug ("%s %s", __func__, error->message);
 }
 
+G_MODULE_EXPORT const gchar*
+g_module_check_init(GModule *module) {
+  g_module_make_resident(module);
+  return NULL;
+}

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,31 +1,14 @@
-api_version = '0.1'
-
 clippy_sources = [
   'utils.c',
   'clippy.c',
 ]
 
-version_split = meson.project_version().split('.')
-MAJOR_VERSION = version_split[0]
-MINOR_VERSION = version_split[1]
-MICRO_VERSION = version_split[2]
-
-version_conf = configuration_data()
-version_conf.set('VERSION', meson.project_version())
-version_conf.set('MAJOR_VERSION', MAJOR_VERSION)
-version_conf.set('MINOR_VERSION', MINOR_VERSION)
-version_conf.set('MICRO_VERSION', MICRO_VERSION)
-
-configure_file(
-  input: 'clippy-version.h.in',
-  output: 'clippy-version.h',
-  configuration: version_conf,
-  install: true,
-  install_dir: join_paths(get_option('includedir'), 'clippy')
-)
+gtk_name = 'gtk+-3.0'
+gtk_dep = dependency(gtk_name, version: '>= 3.22')
 
 clippy_deps = [
-  dependency('gtk+-3.0', version: '>= 3.22'),
+  gtk_dep,
+  dependency('gmodule-2.0'),
 ]
 
 gnome = import('gnome')
@@ -35,21 +18,14 @@ clippy_sources += gnome.compile_resources(
     c_name: 'clippy'
 )
 
-clippy_lib = shared_library('clippy-' + api_version,
+gtk_modules_path = join_paths(gtk_name,
+                              gtk_dep.get_pkgconfig_variable('gtk_binary_version'),
+                              'modules')
+
+clippy_lib = shared_module(
+  'clippy-module',
   clippy_sources,
   dependencies: clippy_deps,
   install: true,
-)
-
-pkg = import('pkgconfig')
-
-pkg.generate(
-  description: 'A shared library to add com.endless.Clippy DBus iface to Gtk applications without recompiling them',
-    libraries: clippy_lib,
-         name: 'clippy',
-     filebase: 'clippy-' + api_version,
-      version: meson.project_version(),
-      subdirs: 'clippy',
-     requires: 'glib-2.0',
-  install_dir: join_paths(get_option('libdir'), 'pkgconfig')
+  install_dir: gtk_modules_path
 )


### PR DESCRIPTION
This makes it easy to load Clippy by simply adding it to the modules
folder or by setting it int he GTK_MODULES environment variable.

https://phabricator.endlessm.com/T23746