### PR TITLE
Add Flatpak global overrides file

### DIFF
--- a/data/flatpak-overrides
+++ b/data/flatpak-overrides
@@ -1,0 +1,5 @@
+[Context]
+filesystems=/var/lib/flatpak/app/com.endlessm.Clippy/current/active/files:ro;
+
+[Environment]
+GTK3_MODULES=/var/lib/flatpak/app/com.endlessm.Clippy/current/active/files/lib/libclippy-module.so

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,0 +1,3 @@
+flatpak_overrides_dir = join_paths(get_option('datadir'), 'clippy')
+
+install_data('flatpak-overrides', install_dir: flatpak_overrides_dir)

--- a/meson.build
+++ b/meson.build
@@ -9,4 +9,5 @@ configure_file(
   configuration: config_h,
 )
 
+subdir('data')
 subdir('src')


### PR DESCRIPTION
This file will be linked from the actual Flatpak global overrides file,
so we can easily update those overridden options.

Currently, it is used to ensure that all apps are launched with access
to the Clippy module and with the GTK3 module env var pointing to it.

https://phabricator.endlessm.com/T23834