### PR TITLE
clippy: change the way the Clippy object is registered

### DIFF
--- a/src/clippy.c
+++ b/src/clippy.c
@@ -534,6 +534,14 @@ clippy_method_call (GDBusConnection       *connection,
   GVariant *return_value = NULL;
   Clippy *clip = user_data;
   GError *error = NULL;
+  GApplication *app;
+
+  /* Make sure the app is activated in case it was autostarted
+   * through this method call.
+   */
+  app = g_application_get_default ();
+  if (app && !gtk_application_get_active_window (GTK_APPLICATION (app)))
+    g_application_activate (app);
 
   if (g_strcmp0 (method_name, "Highlight") == 0)
     {

--- a/src/utils.c
+++ b/src/utils.c
@@ -77,6 +77,21 @@ find_object_forall (GtkWidget *widget, gpointer user_data)
     gtk_container_forall ((GtkContainer *) widget, find_object_forall, data);
 }
 
+static void
+ensure_webview_loaded (GObject *view)
+{
+  while (TRUE)
+    {
+      gboolean loading;
+
+      g_object_get (view, "is-loading", &loading, NULL);
+      if (!loading)
+        break;
+
+      gtk_main_iteration_do (TRUE);
+    }
+}
+
 static inline GObject *
 app_get_object (const gchar *name, GError **error)
 {
@@ -151,6 +166,9 @@ app_get_object (const gchar *name, GError **error)
 
               if ((js_object = g_object_get_data (objval, key)))
                   return js_object;
+
+              /* Make sure the webview page is loaded before we execute JS */
+              ensure_webview_loaded (objval);
 
               js_object = clippy_js_proxy_new (objval, js_object_name);
               g_object_set_data_full (js_object,

--- a/src/utils.h
+++ b/src/utils.h
@@ -57,8 +57,7 @@ GQuark clippy_quark (void);
 
 const gchar *object_get_name     (GObject      *object);
 
-gboolean     app_get_object_info (GApplication *app,
-                                  const gchar  *object,
+gboolean     app_get_object_info (const gchar  *object,
                                   const gchar  *property,
                                   const gchar  *signal,
                                   GObject     **gobject,
@@ -69,8 +68,7 @@ gboolean     app_get_object_info (GApplication *app,
 GVariant    *variant_new_value   (const GValue *value);
 
 gboolean     value_set_variant   (GValue       *value,
-                                  GVariant     *variant,
-                                  GApplication *app);
+                                  GVariant     *variant);
 
 void         str_replace_char    (gchar        *str,
                                   gchar         a,


### PR DESCRIPTION
In order to avoid a race condition, we need to export the Clippy
interface before the app registers its bus name.
As part of this change, we export our interface on our own path
instead of reusing the application object path.

https://phabricator.endlessm.com/T24047