### PR TITLE
Move flatpak overrides to image builder

### DIFF
--- a/data/flatpak-overrides
+++ b/data/flatpak-overrides
@@ -1,5 +1,8 @@
 [Context]
 filesystems=/var/lib/flatpak/app/com.endlessm.Clippy/current/active/files:ro;
 
+[Session Bus Policy]
+com.endlessm.HackSoundServer=talk
+
 [Environment]
 GTK3_MODULES=/var/lib/flatpak/app/com.endlessm.Clippy/current/active/files/lib/libclippy-module.so


### PR DESCRIPTION
We need more flatpak overrides than just Clippy, so we add them here. (See commit message for explanation.)

https://phabricator.endlessm.com/T24260