### PR TITLE
data: Add appdata

### DIFF
--- a/com.endlessm.Clippy.Extension.json.in
+++ b/com.endlessm.Clippy.Extension.json.in
@@ -21,6 +21,20 @@
           "branch": "@GIT_CLONE_BRANCH@"
         }
       ]
+    },
+    {
+      "name": "appdata",
+      "buildsystem": "simple",
+      "build-commands": [
+        "install -Dm644 --target-directory=${FLATPAK_DEST}/share/appdata com.endlessm.Clippy.Extension.appdata.xml",
+        "appstream-compose --basename=com.endlessm.Clippy.Extension --prefix=${FLATPAK_DEST} --origin=flatpak com.endlessm.Clippy.Extension"
+      ],
+      "sources": [
+        {
+          "type": "file",
+          "path": "data/com.endlessm.Clippy.Extension.appdata.xml"
+        }
+      ]
     }
   ]
 }

--- a/data/com.endlessm.Clippy.Extension.appdata.xml
+++ b/data/com.endlessm.Clippy.Extension.appdata.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="addon">
+  <id>com.endlessm.Clippy.Extension</id>
+  <extends>com.endlessm.HackComponents</extends>
+  <metadata_license>CC0-1.0</metadata_license>
+  <project_license>LGPL-2.1</project_license>
+  <name>Clippy</name>
+  <summary>Component that makes apps hackable</summary>
+</component>


### PR DESCRIPTION
GNOME Software relies on the AppStream data (generated from the
appdata file) in order to manage apps, so having it ensures that
Clippy always plays better with it.

https://phabricator.endlessm.com/T26020