### PR TITLE
Downgrade the runtime to GNOME 42

### DIFF
--- a/com.hack_computer.Clippy.Extension.json.in
+++ b/com.hack_computer.Clippy.Extension.json.in
@@ -3,7 +3,7 @@
   "branch": "@BRANCH@",
   "runtime": "com.hack_computer.Clubhouse",
   "runtime-version": "@BRANCH@",
-  "sdk": "org.gnome.Sdk//43",
+  "sdk": "org.gnome.Sdk//42",
   "appstream-compose": false,
   "separate-locales": false,
   "build-extension": true,

--- a/examples/meson.build
+++ b/examples/meson.build
@@ -4,6 +4,6 @@ clippy_js_test_sources = [
 
 executable('clippy_js_test',
   clippy_js_test_sources,
-  dependencies: [clippy_dep, dependency('webkit2gtk-4.1')],
+  dependencies: [clippy_dep, dependency('webkit2gtk-4.0')],
   install: false,
 )


### PR DESCRIPTION
The Asyncio of clubhouse has compatibility issue with Python 3.10+ [1]. And, GNOME 43 runtime has Python 3.10. However, we has not had a way to fix the issue, yet. Therefore, downgrade the runtime to GNOME 42 to gain more time to fix the Asyncio compatibilty issue between clubhouse and Python 3.10+.

[1]: https://github.com/flathub/com.hack_computer.Clubhouse/issues/22#issuecomment-1352841349

https://phabricator.endlessm.com/T34137